### PR TITLE
fix(config): fix clippy warnings

### DIFF
--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -149,7 +149,7 @@ impl BuildArgs {
     /// Converts all build arguments to the corresponding project config
     ///
     /// Defaults to DAppTools-style repo layout, but can be customized.
-    pub fn project(&self, config: Config) -> eyre::Result<Project> {
+    pub fn project(&self, _config: Config) -> eyre::Result<Project> {
         // 0. merge the config
         // TODO this should probably be done separately, so that other commands can also access
 
@@ -253,7 +253,7 @@ impl BuildArgs {
     }
 }
 
-pub fn project(config: Config) -> eyre::Result<Project> {
+pub fn project(_config: Config) -> eyre::Result<Project> {
     todo!()
 }
 

--- a/cli/src/cmd/create.rs
+++ b/cli/src/cmd/create.rs
@@ -46,7 +46,7 @@ impl Cmd for CreateArgs {
         // Find Project & Compile
         let config = utils::load_config();
         // TODO merge
-        let project = self.opts.project(config.clone())?;
+        let project = self.opts.project(config)?;
         let compiled = super::compile(&project)?;
 
         // Get ABI and BIN

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -211,13 +211,15 @@ impl Config {
     /// `Config::with_root`
     ///
     /// This joins all relative paths with the current root and attempts to make them canonic
+    #[must_use]
     pub fn canonic(self) -> Self {
         let root = self.__root.0.clone();
         self.canonic_at(root)
     }
 
     /// Joins all relative paths with the given root
-    pub fn canonic_at(self, root: impl AsRef<Path>) -> Self {
+    #[must_use]
+    pub fn canonic_at(self, _root: impl AsRef<Path>) -> Self {
         todo!()
     }
 


### PR DESCRIPTION
This PR fixes clippy warning that stem from unused variables and redundant clones that are causing the CI to fail